### PR TITLE
fix cr request notification

### DIFF
--- a/helpers/gh_events.py
+++ b/helpers/gh_events.py
@@ -15,10 +15,10 @@ def gh_event_handler(event_category, event):
     elif event_category == 'pull_request':
         if event_action in ['opened', 'synchronize']:
             on_pr_update(event)
-    else:
-        if event_action in ['review_requested', 'review_request_removed']:
+        elif event_action in ['review_requested', 'review_request_removed']:
             review_requested_handler(event)
-        elif event_action == 'submitted':
+    else:
+        if event_action == 'submitted':
             review_submitted_handler(event)
         else:
             logger.info('I am else of gh_event_handler')


### PR DESCRIPTION
CR request notification stopped working
The reason is `'review_requested', 'review_request_removed'` is in `pull_request` category, it will never be called with current implementation. The bug was introduced in #9 .